### PR TITLE
Add customizable OpenAI endpoint URL preference

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,8 +44,6 @@ class KeywordQueryEventListener(EventListener):
     """
 
     def on_event(self, event, extension):
-        endpoint = "https://api.openai.com/v1/chat/completions"
-
         logger.info('Processing user preferences')
         # Get user preferences
         try:
@@ -59,6 +57,7 @@ class KeywordQueryEventListener(EventListener):
             system_prompt = extension.preferences['system_prompt']
             line_wrap = int(extension.preferences['line_wrap'])
             model = extension.preferences['model']
+            endpoint = extension.preferences['endpoint_url']
         # pylint: disable=broad-except
         except Exception as err:
             logger.error('Failed to parse preferences: %s', str(err))

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,13 @@
             "default_value": "gpt-3.5-turbo"
         },
         {
+            "id": "endpoint_url",
+            "type": "input",
+            "name": "OpenAI API endpoint URL",
+            "description": "The OpenAI API endpoint URL (default: https://api.openai.com/v1/chat/completions)",
+            "default_value": "https://api.openai.com/v1/chat/completions"
+        },
+        {
             "id": "line_wrap",
             "type": "input",
             "name": "Line Length",


### PR DESCRIPTION
Allow users to configure the OpenAI API endpoint URL through extension preferences, similar to how the model can be customized. 

This enables compatibility with OpenAI-compatible APIs and custom endpoints.

For example, I use this extension with Qwen 3 235B served by cerebras.ai